### PR TITLE
Fixed corrupting data when rebuilding DCX files.

### DIFF
--- a/DeS-BNDBuild/DeS_BNDBuild.vb
+++ b/DeS-BNDBuild/DeS_BNDBuild.vb
@@ -1132,7 +1132,7 @@ Public Class Des_BNDBuild
                 UINTToBytes(&H2C, &H14)
                 StrToBytes("DCS", &H18)
                 UINTToBytes(currFileSize, &H1C)
-                UINTToBytes(cmpBytes.Length + 2, &H20)
+                UINTToBytes(cmpBytes.Length + 4, &H20)
                 StrToBytes("DCP", &H24)
                 StrToBytes("DFLT", &H28)
                 UINTToBytes(&H20, &H2C)

--- a/DeS-BNDBuild/DeS_BNDBuild.vb
+++ b/DeS-BNDBuild/DeS_BNDBuild.vb
@@ -1132,7 +1132,7 @@ Public Class Des_BNDBuild
                 UINTToBytes(&H2C, &H14)
                 StrToBytes("DCS", &H18)
                 UINTToBytes(currFileSize, &H1C)
-                UINTToBytes(cmpBytes.Length, &H20)
+                UINTToBytes(cmpBytes.Length + 2, &H20)
                 StrToBytes("DCP", &H24)
                 StrToBytes("DFLT", &H28)
                 UINTToBytes(&H20, &H2C)


### PR DESCRIPTION
I got an error when I tried rebuilding into a dcx or bnd file, I don't remember. In trying to diagnose it, I noticed that if you have a DCX file and keep pressing extract and rebuild over and over, the DCX and extracted file keep getting smaller and smaller, becoming corrupt.

I think you basically have to say that the compressed data in the DCX is 2 bytes longer than it actually is? (And this is after skipping two bytes at the beginning???)  Or like, the header is 4C bytes long, not 4E bytes as the code implies, and there's a 2 byte header before the compressed data.

Yet another file format oddity from From...

I tested it with DCX files in a bunch of directories and it all works. Even compared the first decompression with the tenth one with md5 hashes.